### PR TITLE
fix: RoomControllerTest에서 불필요한 when절을 삭제한다

### DIFF
--- a/src/test/java/org/timinggame/api/room/controller/RoomControllerTest.java
+++ b/src/test/java/org/timinggame/api/room/controller/RoomControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDateTime;
 import java.util.Random;
+
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.timinggame.api.fixture.RoomFixture;
@@ -39,9 +40,6 @@ class RoomControllerTest extends RoomControllerUnitTest {
 		// GIVEN
 		final Long roomId = -(new Random().nextLong(Long.MAX_VALUE));
 		final Room room = RoomFixture.inProgressRoom(roomId, LocalDateTime.now(), null);
-
-		// WHEN
-		when(roomService.startGame(anyLong())).thenReturn(room);
 
 		// THEN
 		mockMvc.perform(post(START_GAME_URL, roomId))


### PR DESCRIPTION
<!-- 제목 양식을 지켜주세요! ex. feat: 내용내용내용 -->
### Issue Number
- close #15 

### Summary 
<!-- 구현 기능 설명해주세요 -->
- 테스트 동작에 영향을 주지 않는 when절을 삭제합니다

### Other
<!-- 기타 -->