### PR TITLE
feat: 전역 예외 핸들러를 추가한다

### DIFF
--- a/src/main/java/org/timinggame/api/common/exception/ExceptionRes.java
+++ b/src/main/java/org/timinggame/api/common/exception/ExceptionRes.java
@@ -1,0 +1,24 @@
+package org.timinggame.api.common.exception;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExceptionRes {
+
+	private LocalDateTime timeStamp;
+	private String path;
+	private String description;
+	private String detail;
+
+	public ExceptionRes(String path, String description, String detail) {
+		this.timeStamp = LocalDateTime.now();
+		this.path = path;
+		this.description = description;
+		this.detail = detail;
+	}
+}

--- a/src/main/java/org/timinggame/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/timinggame/api/common/exception/GlobalExceptionHandler.java
@@ -23,14 +23,14 @@ public class GlobalExceptionHandler {
 			.map(violation -> violation.getMessage())
 			.collect(Collectors.joining(", "));
 		return ResponseEntity.badRequest().body(
-			new ExceptionRes(req.getRequestURL().toString(), "유효성 검증에 실패했습니다.", message));
+			new ExceptionRes(req.getRequestURL().toString(), ex.getClass().getSimpleName(), message));
 	}
 
 	@ExceptionHandler(RoomException.class)
 	public ResponseEntity<ExceptionRes> handlerRoomException(HttpServletRequest req, RoomException ex) {
 		printLogFailedRequest(req);
 		return ResponseEntity.status(ex.getStatus()).body(
-			new ExceptionRes(req.getRequestURL().toString(), ex.getCause().toString(), ex.getMessage()));
+			new ExceptionRes(req.getRequestURL().toString(), ex.getClass().getSimpleName(), ex.getMessage()));
 	}
 
 	private void printLogFailedRequest(HttpServletRequest req) {

--- a/src/main/java/org/timinggame/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/timinggame/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package org.timinggame.api.common.exception;
+
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.timinggame.api.room.exception.RoomException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ExceptionRes> handleConstraintViolationException(HttpServletRequest req,
+		ConstraintViolationException ex) {
+		printLogFailedRequest(req);
+		String message = ex.getConstraintViolations().stream()
+			.map(violation -> violation.getMessage())
+			.collect(Collectors.joining(", "));
+		return ResponseEntity.badRequest().body(
+			new ExceptionRes(req.getRequestURL().toString(), "유효성 검증에 실패했습니다.", message));
+	}
+
+	@ExceptionHandler(RoomException.class)
+	public ResponseEntity<ExceptionRes> handlerRoomException(HttpServletRequest req, RoomException ex) {
+		printLogFailedRequest(req);
+		return ResponseEntity.status(ex.getStatus()).body(
+			new ExceptionRes(req.getRequestURL().toString(), ex.getCause().toString(), ex.getMessage()));
+	}
+
+	private void printLogFailedRequest(HttpServletRequest req) {
+		StringBuffer sb = new StringBuffer();
+		String httpMethod = req.getMethod();
+		String requestURL = req.getRequestURL().toString();
+		String failedRequestInfo = sb.append(httpMethod).append(" :: ").append(requestURL).toString();
+		log.error(failedRequestInfo);
+	}
+}

--- a/src/main/java/org/timinggame/api/room/controller/RoomController.java
+++ b/src/main/java/org/timinggame/api/room/controller/RoomController.java
@@ -1,6 +1,7 @@
 package org.timinggame.api.room.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import org.timinggame.api.room.service.RoomService;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RequestMapping("/v1/room")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/org/timinggame/api/room/exception/AlreadyGameStartedException.java
+++ b/src/main/java/org/timinggame/api/room/exception/AlreadyGameStartedException.java
@@ -1,6 +1,6 @@
 package org.timinggame.api.room.exception;
 
-public class AlreadyGameStartedException extends RuntimeException {
+public class AlreadyGameStartedException extends RoomException {
 	public AlreadyGameStartedException(String message) {
 		super(message);
 	}

--- a/src/main/java/org/timinggame/api/room/exception/AlreadyGameStartedException.java
+++ b/src/main/java/org/timinggame/api/room/exception/AlreadyGameStartedException.java
@@ -1,5 +1,7 @@
 package org.timinggame.api.room.exception;
 
+import org.springframework.http.HttpStatus;
+
 public class AlreadyGameStartedException extends RoomException {
 	public AlreadyGameStartedException(String message) {
 		super(message);
@@ -22,4 +24,10 @@ public class AlreadyGameStartedException extends RoomException {
 		boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
 	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+
 }

--- a/src/main/java/org/timinggame/api/room/exception/NoPinCodeException.java
+++ b/src/main/java/org/timinggame/api/room/exception/NoPinCodeException.java
@@ -1,5 +1,7 @@
 package org.timinggame.api.room.exception;
 
+import org.springframework.http.HttpStatus;
+
 public class NoPinCodeException extends RoomException {
 	public NoPinCodeException(String message) {
 		super(message);
@@ -21,5 +23,10 @@ public class NoPinCodeException extends RoomException {
 		boolean enableSuppression,
 		boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return HttpStatus.BAD_REQUEST;
 	}
 }

--- a/src/main/java/org/timinggame/api/room/exception/NoPinCodeException.java
+++ b/src/main/java/org/timinggame/api/room/exception/NoPinCodeException.java
@@ -1,6 +1,6 @@
 package org.timinggame.api.room.exception;
 
-public class NoPinCodeException extends RuntimeException {
+public class NoPinCodeException extends RoomException {
 	public NoPinCodeException(String message) {
 		super(message);
 	}

--- a/src/main/java/org/timinggame/api/room/exception/NoRoomException.java
+++ b/src/main/java/org/timinggame/api/room/exception/NoRoomException.java
@@ -1,5 +1,7 @@
 package org.timinggame.api.room.exception;
 
+import org.springframework.http.HttpStatus;
+
 public class NoRoomException extends RoomException {
 	public NoRoomException(String message) {
 		super(message);
@@ -21,5 +23,10 @@ public class NoRoomException extends RoomException {
 		boolean enableSuppression,
 		boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return HttpStatus.BAD_REQUEST;
 	}
 }

--- a/src/main/java/org/timinggame/api/room/exception/NoRoomException.java
+++ b/src/main/java/org/timinggame/api/room/exception/NoRoomException.java
@@ -1,6 +1,6 @@
 package org.timinggame.api.room.exception;
 
-public class NoRoomException extends RuntimeException {
+public class NoRoomException extends RoomException {
 	public NoRoomException(String message) {
 		super(message);
 	}

--- a/src/main/java/org/timinggame/api/room/exception/RoomExceededException.java
+++ b/src/main/java/org/timinggame/api/room/exception/RoomExceededException.java
@@ -1,6 +1,6 @@
 package org.timinggame.api.room.exception;
 
-public class RoomExceededException extends RuntimeException {
+public class RoomExceededException extends RoomException {
 	public RoomExceededException(String message) {
 		super(message);
 	}

--- a/src/main/java/org/timinggame/api/room/exception/RoomExceededException.java
+++ b/src/main/java/org/timinggame/api/room/exception/RoomExceededException.java
@@ -1,5 +1,7 @@
 package org.timinggame.api.room.exception;
 
+import org.springframework.http.HttpStatus;
+
 public class RoomExceededException extends RoomException {
 	public RoomExceededException(String message) {
 		super(message);
@@ -21,5 +23,10 @@ public class RoomExceededException extends RoomException {
 		boolean enableSuppression,
 		boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return HttpStatus.BAD_REQUEST;
 	}
 }

--- a/src/main/java/org/timinggame/api/room/exception/RoomException.java
+++ b/src/main/java/org/timinggame/api/room/exception/RoomException.java
@@ -1,0 +1,22 @@
+package org.timinggame.api.room.exception;
+
+public abstract class RoomException extends RuntimeException {
+	public RoomException() {
+	}
+
+	public RoomException(String message) {
+		super(message);
+	}
+
+	public RoomException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public RoomException(Throwable cause) {
+		super(cause);
+	}
+
+	public RoomException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/org/timinggame/api/room/exception/RoomException.java
+++ b/src/main/java/org/timinggame/api/room/exception/RoomException.java
@@ -1,8 +1,12 @@
 package org.timinggame.api.room.exception;
 
+import org.springframework.http.HttpStatus;
+
 public abstract class RoomException extends RuntimeException {
-	public RoomException() {
-	}
+
+	public abstract HttpStatus getStatus();
+
+	public RoomException() {}
 
 	public RoomException(String message) {
 		super(message);

--- a/src/main/java/org/timinggame/api/room/exception/RoomException.java
+++ b/src/main/java/org/timinggame/api/room/exception/RoomException.java
@@ -6,21 +6,21 @@ public abstract class RoomException extends RuntimeException {
 
 	public abstract HttpStatus getStatus();
 
-	public RoomException() {}
+	protected RoomException() {}
 
-	public RoomException(String message) {
+	protected RoomException(String message) {
 		super(message);
 	}
 
-	public RoomException(String message, Throwable cause) {
+	protected RoomException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	public RoomException(Throwable cause) {
+	protected RoomException(Throwable cause) {
 		super(cause);
 	}
 
-	public RoomException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+	protected RoomException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
 	}
 }

--- a/src/test/java/org/timinggame/api/room/controller/RoomControllerTest.java
+++ b/src/test/java/org/timinggame/api/room/controller/RoomControllerTest.java
@@ -41,7 +41,6 @@ class RoomControllerTest extends RoomControllerUnitTest {
 	void 게임을_시작할_때_존재하지_않는_방이면_예외를_던진다() throws Exception {
 		// GIVEN
 		final long roomId = 1L;
-		final Room room = RoomFixture.inProgressRoom(roomId, LocalDateTime.now(), null);
 
 		// WHEN
 		when(roomService.startGame(anyLong())).thenThrow(

--- a/src/test/java/org/timinggame/api/room/controller/RoomControllerTest.java
+++ b/src/test/java/org/timinggame/api/room/controller/RoomControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.timinggame.api.fixture.RoomFixture;
 import org.timinggame.api.room.RoomControllerUnitTest;
 import org.timinggame.api.room.domain.Room;
+import org.timinggame.api.room.exception.NoRoomException;
 
 class RoomControllerTest extends RoomControllerUnitTest {
 
@@ -33,6 +34,22 @@ class RoomControllerTest extends RoomControllerUnitTest {
 		mockMvc.perform(post(START_GAME_URL, roomId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.roomId").value(roomId))
+			.andDo(print());
+	}
+
+	@Test
+	void 게임을_시작할_때_존재하지_않는_방이면_예외를_던진다() throws Exception {
+		// GIVEN
+		final long roomId = 1L;
+		final Room room = RoomFixture.inProgressRoom(roomId, LocalDateTime.now(), null);
+
+		// WHEN
+		when(roomService.startGame(anyLong())).thenThrow(
+			new NoRoomException(String.format("%d번 방은 존재하지 않습니다.", roomId)));
+
+		// THEN
+		mockMvc.perform(post(START_GAME_URL, roomId))
+			.andExpect(status().isBadRequest())
 			.andDo(print());
 	}
 


### PR DESCRIPTION
<!-- 제목 양식을 지켜주세요! ex. feat: 내용내용내용 -->
### Issue Number
- close #13 

### Summary 
<!-- 구현 기능 설명해주세요 -->
- Room 도메인 예외를 추상화하고 HttpStatus 반환 추상 메서드를 추가했습니다.
- Controller에 `@Validated`를 추가하여 `ConstraintViolationException` 예외를 던지도록 했습니다.

### Other
<!-- 기타 -->
- [https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4](https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4)