### PR TITLE
feat: mongodb 의존성을 추가한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,6 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
+  data:
+    mongodb:
+      uri: ${MONGO_URI}

--- a/src/test/java/org/timinggame/api/ApiApplicationTests.java
+++ b/src/test/java/org/timinggame/api/ApiApplicationTests.java
@@ -2,8 +2,12 @@ package org.timinggame.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 
 @SpringBootTest
+@EnableAutoConfiguration(exclude = {MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
 class ApiApplicationTests {
 
 	@Test

--- a/src/test/java/org/timinggame/api/ControllerUnitTest.java
+++ b/src/test/java/org/timinggame/api/ControllerUnitTest.java
@@ -1,9 +1,10 @@
 package org.timinggame.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest
 public abstract class ControllerUnitTest {


### PR DESCRIPTION
<!-- 제목 양식을 지켜주세요! ex. feat: 내용내용내용 -->
### Issue Number
- close #20 

### Summary 
<!-- 구현 기능 설명해주세요 -->
- 통합 테스트는 없기 때문에 자동설정을 제외시켰습니다.
- 이후에는 테스트컨테이너를 사용해서 테스트 환경에서 몽고DB를 사용할 수 있도록 설정해야 합니다.

### Other
<!-- 기타 -->